### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/AlchemyPlantProvider.java
+++ b/src/main/java/org/terasology/AlchemyPlantProvider.java
@@ -86,9 +86,9 @@ public class AlchemyPlantProvider implements FacetProviderPlugin, ConfigurableFa
         this.configuration = (AlchemyPlantConfiguration) configuration;
     }
 
-    private static class AlchemyPlantConfiguration implements Component<AlchemyPlantConfiguration> {
+    public static class AlchemyPlantConfiguration implements Component<AlchemyPlantConfiguration> {
         @Range(min = 0.0f, max = 100f, increment = 25f, precision = 1, description = "Plant Rarity")
-        private float plantRarity = 50f;
+        public float plantRarity = 50f;
 
         @Override
         public void copyFrom(AlchemyPlantConfiguration other) {


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191